### PR TITLE
Port manifest to use Okteto manifest.

### DIFF
--- a/okteto-pipeline.yaml
+++ b/okteto-pipeline.yaml
@@ -1,4 +1,0 @@
-deploy:
-- okteto build -t okteto.dev/go-guestbook:$OKTETO_GIT_COMMIT
-- cd manifests; kustomize edit set image okteto/guestbook:golang=okteto.dev/go-guestbook:$OKTETO_GIT_COMMIT
-- kubectl apply -k manifests

--- a/okteto.yaml
+++ b/okteto.yaml
@@ -1,0 +1,20 @@
+build:
+  guestbook:
+    image: okteto.dev/go-guestbook:$OKTETO_GIT_COMMIT
+    dockerfile: Dockerfile
+  dev:
+    dockerfile: Dockerfile
+    target: dev
+
+deploy:
+  - cd manifests; kustomize edit set image okteto/guestbook:golang=${OKTETO_BUILD_GUESTBOOK_IMAGE}
+  - kubectl apply -k manifests
+dev:
+  guestbook:
+    command: ["bash"]
+    forward:
+      - 8080:8080
+      - 9229:9229
+    image: ${OKTETO_BUILD_DEV_IMAGE}
+    sync:
+      - .:/usr/src/app

--- a/okteto.yaml
+++ b/okteto.yaml
@@ -1,8 +1,6 @@
 build:
   guestbook:
     dockerfile: Dockerfile
-  dev:
-    dockerfile: Dockerfile
 
 deploy:
   - cd manifests; kustomize edit set image ${OKTETO_BUILD_GUESTBOOK_IMAGE}
@@ -13,6 +11,6 @@ dev:
     forward:
       - 8080:8080
       - 9229:9229
-    image: ${OKTETO_BUILD_DEV_IMAGE}
+    image: ${OKTETO_BUILD_GUESTBOOK_IMAGE}
     sync:
       - .:/usr/src/app

--- a/okteto.yaml
+++ b/okteto.yaml
@@ -1,13 +1,11 @@
 build:
   guestbook:
-    image: okteto.dev/go-guestbook:$OKTETO_GIT_COMMIT
     dockerfile: Dockerfile
   dev:
     dockerfile: Dockerfile
-    target: dev
 
 deploy:
-  - cd manifests; kustomize edit set image okteto/guestbook:golang=${OKTETO_BUILD_GUESTBOOK_IMAGE}
+  - cd manifests; kustomize edit set image ${OKTETO_BUILD_GUESTBOOK_IMAGE}
   - kubectl apply -k manifests
 dev:
   guestbook:


### PR DESCRIPTION
I have updated the manifest ( previously `okteto-pipeline.yaml` ) in accordance with the new CLI 2.0.